### PR TITLE
Supporting target aliases

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -256,7 +256,7 @@ class Manof(object):
                 cls_names.append(self._alias_target_map[target])
                 continue
 
-            raise RuntimeError('Failed to find target in manofest module: {0}'.format(target))
+            self._logger.info('Failed to find target in manofest module. Skipping', target=target)
 
         return cls_names
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -199,7 +199,9 @@ class Manof(object):
         manofest_module = imp.load_source('manofest', manofest_path)
 
         # normalize to cls names
-        excluded_targets = self._normalize_target_names_to_cls_names(manofest_module, excluded_targets)
+        excluded_targets = self._normalize_target_names_to_cls_names(manofest_module,
+                                                                     excluded_targets,
+                                                                     skip_missing=True)
         targets = self._normalize_target_names_to_cls_names(manofest_module, self._args.targets)
 
         # create instances of the targets passed in the args
@@ -232,7 +234,7 @@ class Manof(object):
 
         return target_instances
 
-    def _normalize_target_names_to_cls_names(self, manofest_module, raw_target_names):
+    def _normalize_target_names_to_cls_names(self, manofest_module, raw_target_names, skip_missing=False):
 
         # load aliases
         self._populate_alias_target_map(manofest_module)
@@ -258,7 +260,10 @@ class Manof(object):
                 cls_names.append(self._alias_target_map[target])
                 continue
 
-            self._logger.info('Failed to find target in manofest module. Skipping', target=target)
+            if skip_missing:
+                self._logger.info('Failed to find target in manofest module. Skipping', target=target)
+            else:
+                raise RuntimeError('Failed to find target in manofest module: {0}'.format(target))
 
         return cls_names
 

--- a/examples/basic/manofest.py
+++ b/examples/basic/manofest.py
@@ -134,6 +134,10 @@ class ImageA(manof.Image):
 
 class ImageB(ImageA):
 
+    @classmethod
+    def alias(cls):
+        return 'imageb'
+
     @property
     def env(self):
         return [
@@ -168,7 +172,10 @@ class VolumeA(manof.NamedVolume):
 
 
 class VolumeB(VolumeA):
-    pass
+    @classmethod
+    def alias(cls):
+        return 'volb'
+
 
 #
 # Image groups

--- a/manof/target.py
+++ b/manof/target.py
@@ -61,6 +61,10 @@ class Target(object):
     def name(self):
         return inflection.underscore(self.__class__.__name__)
 
+    @classmethod
+    def alias(cls):
+        return None
+
     @property
     def dependent_targets(self):
         return self._dependent_targets


### PR DESCRIPTION
Use can now define a `classsmethod` alias for any target class (image, group, volume, ..).
The target is now referable by the alias, e.g: `manof run nickname` for a class `SomeClass` defining the alias:
```
class SomeClass(manof.Target):
    @classmethod
    def alias(cls):
        return 'nickname'
```
This is to allow a more flexible target referral then our current  `inflection.underscore()` direct translation of class names.

Note that the `alias` is a `classmethod` and not the traditional `property` - this may be an inconvenience but is necessary so we don't have to instantiate all manofest classes just to inspect aliases