### PR TITLE
Add cap and devices support

### DIFF
--- a/manof.py
+++ b/manof.py
@@ -95,6 +95,10 @@ def _register_arguments(parser):
                              help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
     run_command.add_argument('--device-read-iops',
                              help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
+    run_command.add_argument('--device-write-bps',
+                             help='Limit write rate (bytes per second) to a device (e.g. /dev/sda:50mb)')
+    run_command.add_argument('--device-write-iops',
+                             help='Limit write rate (IO per second) to a device (e.g. /dev/sda:50)')
     run_command.add_argument('-dv',
                              '--delete-volumes',
                              help='Image: Delete named_volumes that are used by this image',
@@ -138,6 +142,10 @@ def _register_arguments(parser):
                               help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
     lift_command.add_argument('--device-read-iops',
                               help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
+    lift_command.add_argument('--device-write-bps',
+                              help='Limit write rate (bytes per second) to a device (e.g. /dev/sda:50mb)')
+    lift_command.add_argument('--device-write-iops',
+                              help='Limit write rate (IO per second) to a device (e.g. /dev/sda:50)')
     lift_command.add_argument('--cap-add', help='Add capability to the container', action='append')
     lift_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 

--- a/manof.py
+++ b/manof.py
@@ -85,7 +85,10 @@ def _register_arguments(parser):
     run_command = subparsers.add_parser('run', help='Run target containers')
     run_command.add_argument('targets', nargs='+')
     run_command.add_argument('--privileged', action='store_true', help='Give extended privileges to these containers')
-    run_command.add_argument('--device', help='Add a host device to the containers')
+    run_command.add_argument('--device',
+                             help='Add a host device to the containers (can use multiple times)',
+                             action='append',
+                             dest='devices')
     run_command.add_argument('-dv',
                              '--delete-volumes',
                              help='Image: Delete named_volumes that are used by this image',
@@ -119,7 +122,10 @@ def _register_arguments(parser):
     lift_command = subparsers.add_parser('lift', help='Provision and run targets')
     lift_command.add_argument('targets', nargs='+')
     lift_command.add_argument('--privileged', action='store_true', help='Give extended privileges to these containers')
-    lift_command.add_argument('--device', help='Add a host device to the containers')
+    lift_command.add_argument('--device',
+                              help='Add a host device to the containers (can use multiple times)',
+                              action='append',
+                              dest='devices')
     lift_command.add_argument('--cap-add', help='Add capability to the container', action='append')
     lift_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 

--- a/manof.py
+++ b/manof.py
@@ -93,6 +93,8 @@ def _register_arguments(parser):
                              help='Add a rule to the cgroup allowed devices list')
     run_command.add_argument('--device-read-bps',
                              help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
+    run_command.add_argument('--device-read-iops',
+                             help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
     run_command.add_argument('-dv',
                              '--delete-volumes',
                              help='Image: Delete named_volumes that are used by this image',
@@ -134,6 +136,8 @@ def _register_arguments(parser):
                               help='Add a rule to the cgroup allowed devices list')
     lift_command.add_argument('--device-read-bps',
                               help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
+    lift_command.add_argument('--device-read-iops',
+                              help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
     lift_command.add_argument('--cap-add', help='Add capability to the container', action='append')
     lift_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 

--- a/manof.py
+++ b/manof.py
@@ -81,31 +81,31 @@ def _register_arguments(parser):
                                         'NamedVolume: Delete existing before creation',
                                    action='store_true')
 
-    run_and_lift_common_parser = argparse.ArgumentParser(add_help=False)
-    run_and_lift_common_parser.add_argument('targets', nargs='+')
-    run_and_lift_common_parser.add_argument('--privileged',
+    run_parent_parser = argparse.ArgumentParser(add_help=False)
+    run_parent_parser.add_argument('targets', nargs='+')
+    run_parent_parser.add_argument('--privileged',
                                             action='store_true',
                                             help='Give extended privileges to these containers')
-    run_and_lift_common_parser.add_argument('--device',
+    run_parent_parser.add_argument('--device',
                                             help='Add a host device to the containers (can be used multiple times)',
                                             action='append',
                                             dest='devices')
-    run_and_lift_common_parser.add_argument('--device-cgroup-rule',
+    run_parent_parser.add_argument('--device-cgroup-rule',
                                             help='Add a rule to the cgroup allowed devices list (e.g. c\ 42:*\ rmw)')
-    run_and_lift_common_parser \
+    run_parent_parser \
         .add_argument('--device-read-bps',
                       help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
-    run_and_lift_common_parser.add_argument('--device-read-iops',
+    run_parent_parser.add_argument('--device-read-iops',
                                             help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
-    run_and_lift_common_parser.add_argument('--device-write-bps',
+    run_parent_parser.add_argument('--device-write-bps',
                                             help='Limit write rate (bytes per second) to a device (e.g. /dev/sda:50mb)')
-    run_and_lift_common_parser.add_argument('--device-write-iops',
+    run_parent_parser.add_argument('--device-write-iops',
                                             help='Limit write rate (IO per second) to a device (e.g. /dev/sda:50)')
-    run_and_lift_common_parser.add_argument('--cap-add', help='Add capability to the container', action='append')
-    run_and_lift_common_parser.add_argument('--cap-drop', help='Drop capability from the container', action='append')
+    run_parent_parser.add_argument('--cap-add', help='Add capability to the container', action='append')
+    run_parent_parser.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 
     # run
-    run_command = subparsers.add_parser('run', help='Run target containers', parents=[run_and_lift_common_parser])
+    run_command = subparsers.add_parser('run', help='Run target containers', parents=[run_parent_parser])
     run_command.add_argument('-dv',
                              '--delete-volumes',
                              help='Image: Delete named_volumes that are used by this image',
@@ -134,7 +134,7 @@ def _register_arguments(parser):
     rm_command.add_argument('targets', nargs='+')
 
     # lift
-    lift_command = subparsers.add_parser('lift', help='Provision and run targets', parents=[run_and_lift_common_parser])
+    lift_command = subparsers.add_parser('lift', help='Provision and run targets', parents=[run_parent_parser])
 
     # serialize
     serialize_command = subparsers.add_parser('serialize', help='Get a JSON representation of the targets')

--- a/manof.py
+++ b/manof.py
@@ -91,6 +91,8 @@ def _register_arguments(parser):
                              dest='devices')
     run_command.add_argument('--device-cgroup-rule',
                              help='Add a rule to the cgroup allowed devices list')
+    run_command.add_argument('--device-read-bps',
+                             help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
     run_command.add_argument('-dv',
                              '--delete-volumes',
                              help='Image: Delete named_volumes that are used by this image',
@@ -130,6 +132,8 @@ def _register_arguments(parser):
                               dest='devices')
     lift_command.add_argument('--device-cgroup-rule',
                               help='Add a rule to the cgroup allowed devices list')
+    lift_command.add_argument('--device-read-bps',
+                              help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
     lift_command.add_argument('--cap-add', help='Add capability to the container', action='append')
     lift_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 

--- a/manof.py
+++ b/manof.py
@@ -81,24 +81,31 @@ def _register_arguments(parser):
                                         'NamedVolume: Delete existing before creation',
                                    action='store_true')
 
+    run_and_lift_common_parser = argparse.ArgumentParser(add_help=False)
+    run_and_lift_common_parser.add_argument('targets', nargs='+')
+    run_and_lift_common_parser.add_argument('--privileged',
+                                            action='store_true',
+                                            help='Give extended privileges to these containers')
+    run_and_lift_common_parser.add_argument('--device',
+                                            help='Add a host device to the containers (can be used multiple times)',
+                                            action='append',
+                                            dest='devices')
+    run_and_lift_common_parser.add_argument('--device-cgroup-rule',
+                                            help='Add a rule to the cgroup allowed devices list (e.g. c\ 42:*\ rmw)')
+    run_and_lift_common_parser \
+        .add_argument('--device-read-bps',
+                      help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
+    run_and_lift_common_parser.add_argument('--device-read-iops',
+                                            help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
+    run_and_lift_common_parser.add_argument('--device-write-bps',
+                                            help='Limit write rate (bytes per second) to a device (e.g. /dev/sda:50mb)')
+    run_and_lift_common_parser.add_argument('--device-write-iops',
+                                            help='Limit write rate (IO per second) to a device (e.g. /dev/sda:50)')
+    run_and_lift_common_parser.add_argument('--cap-add', help='Add capability to the container', action='append')
+    run_and_lift_common_parser.add_argument('--cap-drop', help='Drop capability from the container', action='append')
+
     # run
-    run_command = subparsers.add_parser('run', help='Run target containers')
-    run_command.add_argument('targets', nargs='+')
-    run_command.add_argument('--privileged', action='store_true', help='Give extended privileges to these containers')
-    run_command.add_argument('--device',
-                             help='Add a host device to the containers (can be used multiple times)',
-                             action='append',
-                             dest='devices')
-    run_command.add_argument('--device-cgroup-rule',
-                             help='Add a rule to the cgroup allowed devices list (e.g. c\ 42:*\ rmw)')
-    run_command.add_argument('--device-read-bps',
-                             help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
-    run_command.add_argument('--device-read-iops',
-                             help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
-    run_command.add_argument('--device-write-bps',
-                             help='Limit write rate (bytes per second) to a device (e.g. /dev/sda:50mb)')
-    run_command.add_argument('--device-write-iops',
-                             help='Limit write rate (IO per second) to a device (e.g. /dev/sda:50)')
+    run_command = subparsers.add_parser('run', help='Run target containers', parents=[run_and_lift_common_parser])
     run_command.add_argument('-dv',
                              '--delete-volumes',
                              help='Image: Delete named_volumes that are used by this image',
@@ -107,8 +114,6 @@ def _register_arguments(parser):
                              '--print-command-only',
                              help='Will enforce dry run and print the run command only, no logs at all',
                              action='store_true')
-    run_command.add_argument('--cap-add', help='Add capability to the container', action='append')
-    run_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 
     # stop
     stop_command = subparsers.add_parser('stop', help='Stop target containers')
@@ -129,25 +134,7 @@ def _register_arguments(parser):
     rm_command.add_argument('targets', nargs='+')
 
     # lift
-    lift_command = subparsers.add_parser('lift', help='Provision and run targets')
-    lift_command.add_argument('targets', nargs='+')
-    lift_command.add_argument('--privileged', action='store_true', help='Give extended privileges to these containers')
-    lift_command.add_argument('--device',
-                              help='Add a host device to the containers (can be used multiple times)',
-                              action='append',
-                              dest='devices')
-    lift_command.add_argument('--device-cgroup-rule',
-                              help='Add a rule to the cgroup allowed devices list (e.g. c\ 42:*\ rmw)')
-    lift_command.add_argument('--device-read-bps',
-                              help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
-    lift_command.add_argument('--device-read-iops',
-                              help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
-    lift_command.add_argument('--device-write-bps',
-                              help='Limit write rate (bytes per second) to a device (e.g. /dev/sda:50mb)')
-    lift_command.add_argument('--device-write-iops',
-                              help='Limit write rate (IO per second) to a device (e.g. /dev/sda:50)')
-    lift_command.add_argument('--cap-add', help='Add capability to the container', action='append')
-    lift_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
+    lift_command = subparsers.add_parser('lift', help='Provision and run targets', parents=[run_and_lift_common_parser])
 
     # serialize
     serialize_command = subparsers.add_parser('serialize', help='Get a JSON representation of the targets')

--- a/manof.py
+++ b/manof.py
@@ -93,8 +93,9 @@ def _register_arguments(parser):
     run_command.add_argument('-pco',
                              '--print-command-only',
                              help='Will enforce dry run and print the run command only, no logs at all',
-                             action='store_true'
-    )
+                             action='store_true')
+    run_command.add_argument('--cap-add', help='Add capability to the container', action='append')
+    run_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 
     # stop
     stop_command = subparsers.add_parser('stop', help='Stop target containers')
@@ -119,6 +120,8 @@ def _register_arguments(parser):
     lift_command.add_argument('targets', nargs='+')
     lift_command.add_argument('--privileged', action='store_true', help='Give extended privileges to these containers')
     lift_command.add_argument('--device', help='Add a host device to the containers')
+    lift_command.add_argument('--cap-add', help='Add capability to the container', action='append')
+    lift_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 
     # serialize
     serialize_command = subparsers.add_parser('serialize', help='Get a JSON representation of the targets')

--- a/manof.py
+++ b/manof.py
@@ -86,9 +86,11 @@ def _register_arguments(parser):
     run_command.add_argument('targets', nargs='+')
     run_command.add_argument('--privileged', action='store_true', help='Give extended privileges to these containers')
     run_command.add_argument('--device',
-                             help='Add a host device to the containers (can use multiple times)',
+                             help='Add a host device to the containers (can be used multiple times)',
                              action='append',
                              dest='devices')
+    run_command.add_argument('--device-cgroup-rule',
+                             help='Add a rule to the cgroup allowed devices list')
     run_command.add_argument('-dv',
                              '--delete-volumes',
                              help='Image: Delete named_volumes that are used by this image',
@@ -123,9 +125,11 @@ def _register_arguments(parser):
     lift_command.add_argument('targets', nargs='+')
     lift_command.add_argument('--privileged', action='store_true', help='Give extended privileges to these containers')
     lift_command.add_argument('--device',
-                              help='Add a host device to the containers (can use multiple times)',
+                              help='Add a host device to the containers (can be used multiple times)',
                               action='append',
                               dest='devices')
+    lift_command.add_argument('--device-cgroup-rule',
+                              help='Add a rule to the cgroup allowed devices list')
     lift_command.add_argument('--cap-add', help='Add capability to the container', action='append')
     lift_command.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 

--- a/manof.py
+++ b/manof.py
@@ -90,7 +90,7 @@ def _register_arguments(parser):
                              action='append',
                              dest='devices')
     run_command.add_argument('--device-cgroup-rule',
-                             help='Add a rule to the cgroup allowed devices list')
+                             help='Add a rule to the cgroup allowed devices list (e.g. c\ 42:*\ rmw)')
     run_command.add_argument('--device-read-bps',
                              help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
     run_command.add_argument('--device-read-iops',
@@ -137,7 +137,7 @@ def _register_arguments(parser):
                               action='append',
                               dest='devices')
     lift_command.add_argument('--device-cgroup-rule',
-                              help='Add a rule to the cgroup allowed devices list')
+                              help='Add a rule to the cgroup allowed devices list (e.g. c\ 42:*\ rmw)')
     lift_command.add_argument('--device-read-bps',
                               help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
     lift_command.add_argument('--device-read-iops',

--- a/manof/image.py
+++ b/manof/image.py
@@ -176,6 +176,10 @@ class Image(manof.Target):
             if cap:
                 command += '--cap-drop={0} '.format(cap)
 
+        # set device cgroup rule
+        if self.device_cgroup_rule:
+            command += '--device-cgroup-rule={0} '.format(self.device_cgroup_rule)
+
         # set tag
         command += self.image_name + ' '
 
@@ -432,6 +436,13 @@ class Image(manof.Target):
             return self._args.cap_drop
 
         return []
+
+    @property
+    def device_cgroup_rule(self):
+        if 'device_cgroup_rule' in self._args and self._args.device_cgroup_rule:
+            return self._args.device_cgroup_rule
+
+        return None
 
     def to_dict(self):
         d = super(Image, self).to_dict()

--- a/manof/image.py
+++ b/manof/image.py
@@ -180,6 +180,10 @@ class Image(manof.Target):
         if self.device_cgroup_rule:
             command += '--device-cgroup-rule={0} '.format(self.device_cgroup_rule)
 
+        # set device read bps
+        if self.device_read_bps:
+            command += '--device-read-bps={0} '.format(self.device_read_bps)
+
         # set tag
         command += self.image_name + ' '
 
@@ -441,6 +445,13 @@ class Image(manof.Target):
     def device_cgroup_rule(self):
         if 'device_cgroup_rule' in self._args and self._args.device_cgroup_rule:
             return self._args.device_cgroup_rule
+
+        return None
+
+    @property
+    def device_read_bps(self):
+        if 'device_read_bps' in self._args and self._args.device_read_bps:
+            return self._args.device_read_bps
 
         return None
 

--- a/manof/image.py
+++ b/manof/image.py
@@ -184,9 +184,17 @@ class Image(manof.Target):
         if self.device_read_bps:
             command += '--device-read-bps={0} '.format(self.device_read_bps)
 
-        # set device read bps
+        # set device read iops
         if self.device_read_iops:
             command += '--device-read-iops={0} '.format(self.device_read_iops)
+
+        # set device write bps
+        if self.device_write_bps:
+            command += '--device-write-bps={0} '.format(self.device_write_bps)
+
+        # set device write iops
+        if self.device_write_iops:
+            command += '--device-write-iops={0} '.format(self.device_write_iops)
 
         # set tag
         command += self.image_name + ' '
@@ -463,6 +471,20 @@ class Image(manof.Target):
     def device_read_iops(self):
         if 'device_read_iops' in self._args and self._args.device_read_iops:
             return self._args.device_read_iops
+
+        return None
+
+    @property
+    def device_write_bps(self):
+        if 'device_write_bps' in self._args and self._args.device_write_bps:
+            return self._args.device_write_bps
+
+        return None
+
+    @property
+    def device_write_iops(self):
+        if 'device_write_iops' in self._args and self._args.device_write_iops:
+            return self._args.device_write_iops
 
         return None
 

--- a/manof/image.py
+++ b/manof/image.py
@@ -184,6 +184,10 @@ class Image(manof.Target):
         if self.device_read_bps:
             command += '--device-read-bps={0} '.format(self.device_read_bps)
 
+        # set device read bps
+        if self.device_read_iops:
+            command += '--device-read-iops={0} '.format(self.device_read_iops)
+
         # set tag
         command += self.image_name + ' '
 
@@ -452,6 +456,13 @@ class Image(manof.Target):
     def device_read_bps(self):
         if 'device_read_bps' in self._args and self._args.device_read_bps:
             return self._args.device_read_bps
+
+        return None
+
+    @property
+    def device_read_iops(self):
+        if 'device_read_iops' in self._args and self._args.device_read_iops:
+            return self._args.device_read_iops
 
         return None
 

--- a/manof/image.py
+++ b/manof/image.py
@@ -167,6 +167,14 @@ class Image(manof.Target):
         # set name
         command += '--name {0} '.format(self.container_name)
 
+        for cap in self.cap_add:
+            if cap:
+                command += '--cap-add={0} '.format(cap)
+
+        for cap in self.cap_drop:
+            if cap:
+                command += '--cap-drop={0} '.format(cap)
+
         # set tag
         command += self.image_name + ' '
 
@@ -408,6 +416,20 @@ class Image(manof.Target):
 
     @property
     def dns(self):
+        return []
+
+    @property
+    def cap_add(self):
+        if 'cap_add' in self._args and self._args.cap_add:
+            return self._args.cap_add
+
+        return []
+
+    @property
+    def cap_drop(self):
+        if 'cap_drop' in self._args and self._args.cap_drop:
+            return self._args.cap_drop
+
         return []
 
     def to_dict(self):

--- a/manof/image.py
+++ b/manof/image.py
@@ -81,9 +81,10 @@ class Image(manof.Target):
         if self.cpuset_cpus:
             command += '--cpuset-cpus {0} '.format(self.cpuset_cpus)
 
-        # add device if needed
-        if self.device is not None:
-            command += '--device={0} '.format(self.device)
+        # add devices
+        for device in self.devices:
+            if device:
+                command += '--device={0} '.format(device)
 
         # add dns if needed, this allowes for the container to resolve addresses using custom dns resolvers
         for dns_ip in self.dns:
@@ -346,11 +347,11 @@ class Image(manof.Target):
         return False
 
     @property
-    def device(self):
-        if 'device' in self._args:
-            return self._args.device
+    def devices(self):
+        if 'devices' in self._args and self._args.devices:
+            return self._args.devices
 
-        return None
+        return []
 
     @property
     def net(self):


### PR DESCRIPTION
Fixed `--device` argument to support multiple devices

Added new `docker run` arguments support:
`--device-cgroup-rule`
`--device-read-bps`
`--device-read-iops`
`--device-write-bps`
`--device-write-iops`
`--cap-add`
`--cap-drop`