### PR TITLE
Manof push fix

### DIFF
--- a/manof.py
+++ b/manof.py
@@ -175,7 +175,7 @@ def _register_arguments(parser):
         cmd_parse.add_argument('-r',
                                '--repository',
                                help='The repository from which images shall be taken from or pushed to',
-                               default='')
+                               default='docker.io')
 
     known_option_strings = parser._option_string_actions.keys()
 

--- a/manof/image.py
+++ b/manof/image.py
@@ -494,7 +494,6 @@ class Image(manof.Target):
             if issubclass(type(item), dict):
                 volume = item.keys()[0]
                 if self._classname_is_subclass(volume, manof.Volume):
-
                     # instantiate
                     named_volume = volume(self._logger, self._args)
                     d['volumes'][idx] = {named_volume.volume_name: item.values()[0]}
@@ -534,7 +533,6 @@ class Image(manof.Target):
         for volume in self.volumes:
             host_path, container_path = volume.items()[0]
             if self._classname_is_subclass(host_path, manof.NamedVolume):
-
                 # instantiate
                 named_volume = host_path(self._logger, self._args)
                 yield named_volume.rm(safe=True)

--- a/manof/image.py
+++ b/manof/image.py
@@ -494,6 +494,7 @@ class Image(manof.Target):
             if issubclass(type(item), dict):
                 volume = item.keys()[0]
                 if self._classname_is_subclass(volume, manof.Volume):
+
                     # instantiate
                     named_volume = volume(self._logger, self._args)
                     d['volumes'][idx] = {named_volume.volume_name: item.values()[0]}
@@ -533,6 +534,7 @@ class Image(manof.Target):
         for volume in self.volumes:
             host_path, container_path = volume.items()[0]
             if self._classname_is_subclass(host_path, manof.NamedVolume):
+
                 # instantiate
                 named_volume = host_path(self._logger, self._args)
                 yield named_volume.rm(safe=True)

--- a/manof/image.py
+++ b/manof/image.py
@@ -262,17 +262,12 @@ class Image(manof.Target):
     def push(self):
         self._logger.debug('Pushing', repository=self._args.repository)
 
-        if self.context:
-            local_image_name = self.image_name.split(':')[0]
-        else:
-            local_image_name = self.image_name
-
         # determine image remote name, repository is mandatory
         remote_image_name = "{0}/{1}".format(self._args.repository, self.image_name)
 
         # tag and push
         yield self._run_command([
-            'docker tag {0} {1}'.format(local_image_name, remote_image_name),
+            'docker tag {0} {1}'.format(self.image_name, remote_image_name),
             'docker push {0}'.format(remote_image_name)
         ])
 

--- a/manof/image.py
+++ b/manof/image.py
@@ -263,7 +263,7 @@ class Image(manof.Target):
         if not self.skip_push:
 
             # determine image remote name, repository is mandatory
-            remote_image_name = "{0}/{1}".format(self._args.repository, self.image_name)
+            remote_image_name = '{0}/{1}'.format(self._args.repository, self.image_name)
 
             # tag and push
             yield self._run_command([
@@ -275,8 +275,8 @@ class Image(manof.Target):
                 yield self._run_command('docker rmi {0}'.format(remote_image_name))
 
             self.pprint_json({
-                "image_name": self.image_name,
-                "remote_image_name": remote_image_name,
+                'image_name': self.image_name,
+                'remote_image_name': remote_image_name,
             })
 
         else:

--- a/manof/image.py
+++ b/manof/image.py
@@ -1,6 +1,5 @@
 import os
 import pipes
-import json
 import inspect
 import re
 
@@ -260,24 +259,28 @@ class Image(manof.Target):
 
     @defer.inlineCallbacks
     def push(self):
-        self._logger.debug('Pushing', repository=self._args.repository)
+        self._logger.debug('Pushing', repository=self._args.repository, skip_push=self.skip_push)
+        if not self.skip_push:
 
-        # determine image remote name, repository is mandatory
-        remote_image_name = "{0}/{1}".format(self._args.repository, self.image_name)
+            # determine image remote name, repository is mandatory
+            remote_image_name = "{0}/{1}".format(self._args.repository, self.image_name)
 
-        # tag and push
-        yield self._run_command([
-            'docker tag {0} {1}'.format(self.image_name, remote_image_name),
-            'docker push {0}'.format(remote_image_name)
-        ])
+            # tag and push
+            yield self._run_command([
+                'docker tag {0} {1}'.format(self.image_name, remote_image_name),
+                'docker push {0}'.format(remote_image_name)
+            ])
 
-        if not self._args.no_cleanup:
-            yield self._run_command('docker rmi {0}'.format(remote_image_name))
+            if not self._args.no_cleanup:
+                yield self._run_command('docker rmi {0}'.format(remote_image_name))
 
-        print(json.dumps({
-            "image_name": self.image_name,
-            "remote_image_name": remote_image_name,
-        }, indent=2))
+            self.pprint_json({
+                "image_name": self.image_name,
+                "remote_image_name": remote_image_name,
+            })
+
+        else:
+            self._logger.debug('Skipping push')
 
     @defer.inlineCallbacks
     def pull(self):

--- a/manof/image.py
+++ b/manof/image.py
@@ -287,7 +287,7 @@ class Image(manof.Target):
         self._logger.debug('Pulling', repository=self._args.repository)
 
         # determine image remote name
-        remote_image_name = "{0}/{1}".format(self._args.repository, self.image_name) \
+        remote_image_name = '{0}/{1}'.format(self._args.repository, self.image_name) \
             if self._args.repository else self.image_name
 
         # first, pull the image


### PR DESCRIPTION
- Use repository argument as 'where to push to'
- Context will help to determine local name & its tag
- Print to stdout on finish so caller can collect data (just `json.loads` on your output from `manof --log-console-severity=W push --repository myRegistry:5000 MyAwesomeDockerName`)