### PR TITLE
Fix: Backwards compatibility for repository argument

### DIFF
--- a/manof.py
+++ b/manof.py
@@ -172,6 +172,7 @@ def _register_arguments(parser):
                                help='Exclude targets when running manof cmd (comma-delimited, no spaces)',
                                default='')
 
+        # TODO: Change default to 'docker.io'. Currently default is None for backwards compatibility
         cmd_parse.add_argument('-r',
                                '--repository',
                                help='The repository from which images shall be taken from or pushed to',

--- a/manof.py
+++ b/manof.py
@@ -175,7 +175,7 @@ def _register_arguments(parser):
         cmd_parse.add_argument('-r',
                                '--repository',
                                help='The repository from which images shall be taken from or pushed to',
-                               default='docker.io')
+                               default=None)
 
     known_option_strings = parser._option_string_actions.keys()
 

--- a/manof/image.py
+++ b/manof/image.py
@@ -260,6 +260,8 @@ class Image(manof.Target):
     @defer.inlineCallbacks
     def push(self):
         if self._args.repository is None:
+
+            # TODO: Remove once self._args.repository's default is set to 'docker.io'
             self._logger.warn('No remote repository was given, setting to \"docker.io\"')
             self._args.repository = 'docker.io'
 
@@ -289,6 +291,8 @@ class Image(manof.Target):
     @defer.inlineCallbacks
     def pull(self):
         if self._args.repository is None:
+
+            # TODO: Remove once self._args.repository's default is set to 'docker.io'
             self._logger.warn('No remote repository was given, setting to \"docker.io\"')
             self._args.repository = 'docker.io'
 

--- a/manof/image.py
+++ b/manof/image.py
@@ -259,6 +259,10 @@ class Image(manof.Target):
 
     @defer.inlineCallbacks
     def push(self):
+        if self._args.repository is None:
+            self._logger.warn('No remote repository was given, setting to \"docker.io\"')
+            self._args.repository = 'docker.io'
+
         self._logger.debug('Pushing', repository=self._args.repository, skip_push=self.skip_push)
         if not self.skip_push:
 
@@ -284,6 +288,10 @@ class Image(manof.Target):
 
     @defer.inlineCallbacks
     def pull(self):
+        if self._args.repository is None:
+            self._logger.warn('No remote repository was given, setting to \"docker.io\"')
+            self._args.repository = 'docker.io'
+
         self._logger.debug('Pulling', repository=self._args.repository)
 
         # determine image remote name


### PR DESCRIPTION
For BC reasons:
- Default value for `--repository` is back to being `None`
- If no `--repository` is given by the user, the commands push/pull override this to be `docker.io`

Tech debt: 

- Set repository argument default to 'docker.io'
- Use repository argument on push\pull commands only