### PR TITLE
Manof provisioning, pull, push should use same repository

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -45,7 +45,7 @@ class Manof(object):
 
     def _ungreedify_targets(self, parsed_args, known_arg_options):
         """
-        We cleanup unkown argument values from the greedy 'targets' nargs. This is to allow using spaces in the
+        We cleanup unknown argument values from the greedy 'targets' nargs. This is to allow using spaces in the
         dynamic (read: coming from manofest) args, otherwise, This: manof lift --a b target will translate to:
         targets= [b, target]. So, to make this none-greedy, we assume that after every unknown arg without '=' in it,
         there's a value. This prohibits the usage of store_true args in manofest, and is enforced

--- a/manof.py
+++ b/manof.py
@@ -82,11 +82,11 @@ def _register_arguments(parser):
                                         'NamedVolume: Delete existing before creation',
                                    action='store_true')
     provision_command.add_argument('-tl',
-                                   '--tag-local',
+                                   '--skip-tag-local',
                                    help='If no context is given, provision will perform pull and '
-                                        'tag the image with its local repository (default: True)',
-                                   default=True,
-                                   action='store_true')
+                                        'skip tagging the image with its local repository (default: False)',
+                                   dest='tag_local',
+                                   action='store_false')
 
     run_parent_parser = argparse.ArgumentParser(add_help=False)
     run_parent_parser.add_argument('targets', nargs='+')

--- a/manof.py
+++ b/manof.py
@@ -44,7 +44,8 @@ def _register_arguments(parser):
     # main command subparser, to which we'll add subparsers below
     subparsers = parser.add_subparsers(dest='command',
                                        title='subcommands',
-                                       description='To print additional help on a subcommand, run manof <subcmd> --help')
+                                       description='To print additional help on a subcommand, '
+                                                   'run manof <subcmd> --help')
 
     # global options for manof
     clients.logging.Client.register_arguments(parser)
@@ -80,27 +81,33 @@ def _register_arguments(parser):
                                    help='Image: Always remove intermediate containers. '
                                         'NamedVolume: Delete existing before creation',
                                    action='store_true')
+    provision_command.add_argument('-tl',
+                                   '--tag-local',
+                                   help='If no context is given, provision will perform pull and '
+                                        'tag the image with its local repository (default: True)',
+                                   default=True,
+                                   action='store_true')
 
     run_parent_parser = argparse.ArgumentParser(add_help=False)
     run_parent_parser.add_argument('targets', nargs='+')
     run_parent_parser.add_argument('--privileged',
-                                            action='store_true',
-                                            help='Give extended privileges to these containers')
+                                   action='store_true',
+                                   help='Give extended privileges to these containers')
     run_parent_parser.add_argument('--device',
-                                            help='Add a host device to the containers (can be used multiple times)',
-                                            action='append',
-                                            dest='devices')
+                                   help='Add a host device to the containers (can be used multiple times)',
+                                   action='append',
+                                   dest='devices')
     run_parent_parser.add_argument('--device-cgroup-rule',
-                                            help='Add a rule to the cgroup allowed devices list (e.g. c\ 42:*\ rmw)')
+                                   help='Add a rule to the cgroup allowed devices list (e.g. c\ 42:*\ rmw)')
     run_parent_parser \
         .add_argument('--device-read-bps',
                       help='Limit read rate (bytes per second) from a device (e.g. /dev/sda:50mb)')
     run_parent_parser.add_argument('--device-read-iops',
-                                            help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
+                                   help='Limit read rate (IO per second) from a device (e.g. /dev/sda:50)')
     run_parent_parser.add_argument('--device-write-bps',
-                                            help='Limit write rate (bytes per second) to a device (e.g. /dev/sda:50mb)')
+                                   help='Limit write rate (bytes per second) to a device (e.g. /dev/sda:50mb)')
     run_parent_parser.add_argument('--device-write-iops',
-                                            help='Limit write rate (IO per second) to a device (e.g. /dev/sda:50)')
+                                   help='Limit write rate (IO per second) to a device (e.g. /dev/sda:50)')
     run_parent_parser.add_argument('--cap-add', help='Add capability to the container', action='append')
     run_parent_parser.add_argument('--cap-drop', help='Drop capability from the container', action='append')
 

--- a/manof/image.py
+++ b/manof/image.py
@@ -34,7 +34,7 @@ class Image(manof.Target):
 
                 try:
 
-                    # write the docker ingore
+                    # write the docker ignore
                     with open(dockerignore_path, 'wb') as dockerignore_file:
                         dockerignore_file.write('\n'.join(self.dockerignore))
 


### PR DESCRIPTION
- Introducing `default_repository` 
- remote_image_name is a composition of repository+image_name whereas the repository is determined by the `default_repository` and the repository arg given by cli (repository arg is being prioritized over `default_repository`)
- `provision` command should use `manof pull` if no context is given
- `provision` command has tag-local set to True by default to have the exact same behavior and output between build,pull
- tag-local fix if repository is `docker.io` (since it is by default omitted, `docker rmi docker.io/X` == `docker rmi X`, and that can lead to the entire removal of the docker image)
- some indentation fixes
- some typos fixes


Usage example
```python
class MyImage(manof.Image):
    @property
    def image_name(self):
        return 'X/Y:Z'

    @property
    def default_repository(self):
        return 'quay.io'
```
…
```
▶ manof pull my_image
...
{"command": "docker pull quay.io/X/Y:Z"}

▶ manof provision my_image
...
{"command": "docker pull quay.io/X/Y:Z"}

▶ manof push my_image
...
{"command": "['docker tag X/Y:Z quay.io/X/Y:Z', 'docker push quay.io/X/Y:Z']"}
```