### PR TITLE
Adding option to pipe stdout and err on run command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.pyc
 bin/
+venv/
 include/
 lib/
 local/

--- a/manof/image.py
+++ b/manof/image.py
@@ -226,8 +226,6 @@ class Image(manof.Target):
                 print >> sys.stdout, out
 
         except Exception as exc:
-            self._logger.warn('Failed running container', err=str(exc))
-
             dangling_container_error = re.search(
                 'endpoint with name (?P<container_name>.*) already exists in network (?P<network>.*).',
                 exc.message)

--- a/manof/image.py
+++ b/manof/image.py
@@ -2,12 +2,12 @@ import os
 import sys
 import pipes
 import inspect
-import utils
 import re
 
 from twisted.internet import defer
 
 import manof
+import utils
 
 
 class Image(manof.Target):

--- a/manof/image.py
+++ b/manof/image.py
@@ -1,6 +1,8 @@
 import os
+import sys
 import pipes
 import inspect
+import utils
 import re
 
 from twisted.internet import defer
@@ -218,7 +220,18 @@ class Image(manof.Target):
             print command
 
         try:
-            yield self._run_command(command)
+            out, _, _ = yield self._run_command(command)
+
+            if self.pipe_stdout:
+                print >> sys.stdout, out
+
+        except utils.CommandFailedError as exc:
+            if self.pipe_stderr:
+                print >> sys.stderr, exc.err
+                sys.exit(exc.code)
+            else:
+                raise exc
+
         except Exception as exc:
             self._logger.warn('Failed running container', err=str(exc))
 
@@ -349,6 +362,14 @@ class Image(manof.Target):
     @property
     def command(self):
         return None
+
+    @property
+    def pipe_stdout(self):
+        return False
+
+    @property
+    def pipe_stderr(self):
+        return False
 
     @property
     def hostname(self):

--- a/manof/image.py
+++ b/manof/image.py
@@ -225,13 +225,6 @@ class Image(manof.Target):
             if self.pipe_stdout:
                 print >> sys.stdout, out
 
-        except utils.CommandFailedError as exc:
-            if self.pipe_stderr:
-                print >> sys.stderr, exc.err
-                sys.exit(exc.code)
-            else:
-                raise exc
-
         except Exception as exc:
             self._logger.warn('Failed running container', err=str(exc))
 
@@ -244,9 +237,17 @@ class Image(manof.Target):
                 network = dangling_container_error.group('network')
                 yield self._disconnect_container_from_network(container_name, network)
 
-                self._logger.debug('Reruning container', command=command)
+                self._logger.debug('Re-running container', command=command)
                 yield self._run_command(command)
+
             else:
+
+                if self.pipe_stderr:
+                    if isinstance(exc, utils.CommandFailedError):
+                        print >> sys.stderr, exc.err
+                    else:
+                        print >> sys.stderr, str(exc)
+
                 raise exc
 
     @defer.inlineCallbacks

--- a/manof/utils/__init__.py
+++ b/manof/utils/__init__.py
@@ -22,6 +22,9 @@ class CommandFailedError(Exception):
         :param signal: the signal which killed the process
         :type signal: int
         """
+        self._code = code
+        self._out = out
+        self._err = err
 
         if code is not None:
             message = '\'{0}\' exited with code {1}'.format(command, code)
@@ -38,6 +41,18 @@ class CommandFailedError(Exception):
             message += '\n (stdout: {0})'.format(out)
 
         super(CommandFailedError, self).__init__(message)
+
+    @property
+    def code(self):
+        return self._code
+
+    @property
+    def out(self):
+        return self._out
+
+    @property
+    def err(self):
+        return self._err
 
 
 def git_pull(logger, path):

--- a/manof/utils/__init__.py
+++ b/manof/utils/__init__.py
@@ -216,7 +216,7 @@ def retry_until_successful(num_of_tries, logger, function, *args, **kwargs):
     """
 
     def _on_operation_callback_error(failure):
-        logger.warn('Exception during operation execution', function=function.__name__, tb=failure.getBriefTraceback())
+        logger.debug('Exception during operation execution', function=function.__name__, tb=failure.getBriefTraceback())
         raise failure
 
     tries = 1


### PR DESCRIPTION
2 new properties to a manof image:
```python
    @property
    def pipe_stdout(self):
        return False

    @property
    def pipe_stderr(self):
        return False
```

These are off by default