### PR TITLE
Bumping twisted version to 19.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 inflection==0.3.1
 simplejson==3.8.2
-Twisted==16.3.0
+Twisted==19.2.1
 pytz==2016.7
 colorama==0.3.3
 pygments==2.2.0


### PR DESCRIPTION
To mitigate some known security issues [not effecting manof]
https://nvd.nist.gov/vuln/detail/CVE-2019-12387

No functional effects