### PR TITLE
Changed 'execute' function's quiet log level from info to debug

### DIFF
--- a/manof/utils/__init__.py
+++ b/manof/utils/__init__.py
@@ -186,7 +186,7 @@ def execute(command, cwd, quiet, env=None, logger=None):
     out = out.strip()
     if code:
         if quiet and logger:
-            logger.info('Command failed quietly', command=command, cwd=cwd, code_or_signal=code, err=err, out=out)
+            logger.debug('Command failed quietly', command=command, cwd=cwd, code_or_signal=code, err=err, out=out)
         else:
             if logger:
                 logger.warn('Command failed', command=command, cwd=cwd, code_or_signal=code, err=err, out=out)


### PR DESCRIPTION
The `manof run` command uses `docker rm` to make sure the containers don't already exists on the system. When no container exists, this returns an error which in turn raises an exception.
However, Manof's execute function has a `quiet` arg which consumes the exception and logs the error 'Command failed quietly'. In order to make the function even quieter, changed the log level from `info` to `debug`