### PR TITLE
Disabled colorma

### DIFF
--- a/clients/logging/__init__.py
+++ b/clients/logging/__init__.py
@@ -3,7 +3,6 @@ import logging.handlers
 import os
 import sys
 
-import colorama
 from twisted.python.log import addObserver
 
 from clients.logging.formatter import helpers
@@ -109,7 +108,9 @@ class Client(object):
         log_colors='on',
     ):
 
-        colorama.init()
+        # disabled - this hijacks stdout and adds RESETCOLOR at the end regardless if we are on atty or not
+        # std colors works without it, so no need for that ATM
+        # colorama.init()
 
         # initialize root logger
         logging.setLoggerClass(_VariableLogging)

--- a/tests/integration/cases/shell_commands/artifacts/manofest.py
+++ b/tests/integration/cases/shell_commands/artifacts/manofest.py
@@ -3,9 +3,21 @@ import manof
 
 class TestImage(manof.Image):
     @property
+    def local_repository(self):
+        return ''
+
+    @property
     def image_name(self):
         return 'busybox:1'
 
     @property
     def command(self):
         return '/bin/sh -c "echo \'{0}\'"'.format(self.name)
+
+
+class SomeGroup(manof.Group):
+    @property
+    def members(self):
+        return [
+            'TestImage',
+        ]

--- a/tests/integration/cases/shell_commands/test_shell_commands.py
+++ b/tests/integration/cases/shell_commands/test_shell_commands.py
@@ -9,13 +9,14 @@ import tests.integration
 class BasicCommandsTestCase(tests.integration.IntegrationTestCase):
     @defer.inlineCallbacks
     def test_serialize(self):
-        results, err, signal = yield self._manof_command(
+        serialized_group_contents, _, _ = yield self._manof_command(
             '--log-console-severity E serialize',
             [
                 'SomeGroup',
             ],
         )
-        simplejson.loads(results)
+        serialized_group = simplejson.loads(serialized_group_contents)
+        self.assertEqual('test_image', serialized_group[0]['name'])
 
     @defer.inlineCallbacks
     def test_run_and_rm(self):

--- a/tests/integration/cases/shell_commands/test_shell_commands.py
+++ b/tests/integration/cases/shell_commands/test_shell_commands.py
@@ -1,3 +1,5 @@
+import simplejson
+
 from twisted.internet import defer
 
 import manof.utils
@@ -5,6 +7,16 @@ import tests.integration
 
 
 class BasicCommandsTestCase(tests.integration.IntegrationTestCase):
+    @defer.inlineCallbacks
+    def test_serialize(self):
+        results, err, signal = yield self._manof_command(
+            '--log-console-severity E serialize',
+            [
+                'SomeGroup',
+            ],
+        )
+        simplejson.loads(results)
+
     @defer.inlineCallbacks
     def test_run_and_rm(self):
         self._logger.info('Testing run command happy flow')

--- a/tools/flake8_plugin/flake8_igz.py
+++ b/tools/flake8_plugin/flake8_igz.py
@@ -19,17 +19,21 @@ class Utils(object):
 
 
 def single_quote_strings(logical_line, tokens):
-    for lexeme, start, _, in Utils.get_string_tokens(
-        tokens
-    ):
+    for (
+        lexeme,
+        start,
+        _,
+    ) in Utils.get_string_tokens(tokens):
         if lexeme.startswith('"') and not lexeme.startswith('"""'):
             yield start, 'I100 double-quote string used (expected single-quote)'
 
 
 def multiline_string_on_newline(logical_line, tokens):
-    for lexeme, start, end, in Utils.get_string_tokens(
-        tokens
-    ):
+    for (
+        lexeme,
+        start,
+        end,
+    ) in Utils.get_string_tokens(tokens):
         if lexeme.startswith('"""'):
             if not re.match(r'^\"\"\"\n', lexeme):
                 yield start, 'I101 multiline string must start on next line after triple double-quotes'
@@ -38,9 +42,11 @@ def multiline_string_on_newline(logical_line, tokens):
 
 
 def multiline_string_double_quotes(logical_line, tokens):
-    for lexeme, start, _, in Utils.get_string_tokens(
-        tokens
-    ):
+    for (
+        lexeme,
+        start,
+        _,
+    ) in Utils.get_string_tokens(tokens):
         if lexeme.startswith('\'\'\''):
             yield start, 'I103 triple single-quotes used in multiline string (expected triple double-quotes)'
 


### PR DESCRIPTION
It simply hijacks stdout and append RESET color at the end regardless if we run with atty or not.
This cause `serialize` command not to work.

Note: colors still work on normal atty stdout